### PR TITLE
Update upload endpoint to use /api prefix

### DIFF
--- a/resume-builder-frontend/server/routes/upload.ts
+++ b/resume-builder-frontend/server/routes/upload.ts
@@ -53,7 +53,7 @@ export const handleUpload: RequestHandler = async (req, res) => {
 
         // Forward to FastAPI backend
         const backendUrl = process.env.BACKEND_URL || 'http://localhost:7777';
-        const response = await fetch(`${backendUrl}/upload`, {
+        const response = await fetch(`${backendUrl}/api/upload`, {
           method: 'POST',
           body: formData,
         });


### PR DESCRIPTION
## Purpose
Update frontend API calls to point to the correct backend endpoint structure. The user requested that all API calls be updated to use the backend running on `http://localhost:7777/api` instead of other URLs to ensure proper routing to the API endpoints.

## Code changes
- Modified the upload route in `resume-builder-frontend/server/routes/upload.ts`
- Updated the fetch URL from `${backendUrl}/upload` to `${backendUrl}/api/upload`
- This ensures the upload functionality correctly targets the `/api` prefix on the backend server

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f4409a3a80204c5097d156c2d5e3dff5/neon-world)

👀 [Preview Link](https://f4409a3a80204c5097d156c2d5e3dff5-neon-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f4409a3a80204c5097d156c2d5e3dff5</projectId>-->
<!--<branchName>neon-world</branchName>-->